### PR TITLE
Preserve symbolic links when zipping xcframeworks

### DIFF
--- a/.scripts/package.sh
+++ b/.scripts/package.sh
@@ -65,7 +65,8 @@ rename_frameworks () {
 zip_frameworks () {
     for i in */*.xcframework; do (
         local name=$(xcframework_name $i)
-        cd "$i/../"; zip -rqo "$name.xcframework.zip" "$name.xcframework"
+        # Preserve symbolic links with -y option
+        cd "$i/../"; zip -ryqo "$name.xcframework.zip" "$name.xcframework"
     ) & done;
     wait
 }


### PR DESCRIPTION
This fixes an issue where the signature of the xcframeworks became invalid after being zipped and unzipped.

It was not an issue until recently because Apple has started to enforce code signing for third-party frameworks.

See more:

- https://developer.apple.com/news/?id=r1henawx
- https://developer.apple.com/support/third-party-SDK-requirements/
- https://github.com/firebase/firebase-ios-sdk/issues/12238